### PR TITLE
Add npm run build step to PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Test npm run build
+on:
+  pull_request:
+    branches:
+    - main
+jobs:
+  build-project:
+    name: Build Next.js project
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v4
+    - name: Install the npm dependencies
+      uses: npm install
+    - name: Build project assets
+      uses: npm run build


### PR DESCRIPTION
Adds a step to build application. Noticing errors on build that needs to be corrected during PRs but isn't able to be seen at time of PR (due to distance from computers).